### PR TITLE
Filtering Collections and Globals

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Autogenerate an OpenAPI specification from your Payload CMS instance and use it 
 - [x] Preferences endpoints
 - [x] Support Payload CMS 3.x
 - [x] Support generating both OpenAPI 3.0 and 3.1
+- [x] Collection and Global filtering options
 - [ ] Custom endpoints
 
 # Installation
@@ -34,7 +35,10 @@ import { openapi } from 'payload-oapi'
 
 buildConfig({
   plugins: [
-    openapi({ openapiVersion: '3.0', metadata: { title: 'Dev API', version: '0.0.1' } }),
+    openapi({ 
+      openapiVersion: '3.0', 
+      metadata: { title: 'Dev API', version: '0.0.1' } 
+    }),
   ],
   // ...
 })
@@ -68,7 +72,68 @@ buildConfig({
 })
 ```
 
+## 3. Filtering Collections and Globals (optional)
+
+You can control which collections and globals are included in the OpenAPI specification using filtering options:
+
+### Include/Exclude by slug
+
+```typescript
+import { openapi } from 'payload-oapi'
+
+buildConfig({
+  plugins: [
+    openapi({
+      openapiVersion: '3.0',
+      metadata: { title: 'Dev API', version: '0.0.1' },
+      // Only include specific collections
+      includeCollections: ['posts', 'users'],
+      // Exclude specific globals
+      excludeGlobals: ['internal-settings'],
+    }),
+  ],
+  // ...
+})
+```
+
+### Custom filtering functions
+
+```typescript
+import { openapi } from 'payload-oapi'
+
+buildConfig({
+  plugins: [
+    openapi({
+      openapiVersion: '3.0',
+      metadata: { title: 'Dev API', version: '0.0.1' },
+      // Include collections based on custom logic
+      includeCollections: ({ slug, config }) => {
+        // Only include collections that have auth enabled or are public
+        return config.auth || config.access?.read === true
+      },
+      // Exclude globals based on custom logic
+      excludeGlobals: ({ slug }) => {
+        // Exclude any globals that start with 'internal-'
+        return slug.startsWith('internal-')
+      },
+    }),
+  ],
+  // ...
+})
+```
+
+### Filtering Options
+
+- `includeCollections`: Array of collection slugs or a filter function. If specified, only these collections will be included.
+- `excludeCollections`: Array of collection slugs or a filter function. These collections will be excluded.
+- `includeGlobals`: Array of global slugs or a filter function. If specified, only these globals will be included.
+- `excludeGlobals`: Array of global slugs or a filter function. These globals will be excluded.
+
+**Note**: Include filters are applied first, then exclude filters. If both are specified, a collection/global must pass both filters to be included.
+
 # Usage
 
-Unless you configured it otherwise, your spec will be accessible via <https://your-payload.com/api/openapi.json>. If you
-added a documentation UI, that will be accessible via <https://your-payload.com/api/docs> (this is also configurable).
+By default, the following endpoints are available:
+
+- OpenAPI Specification: `https://your-payload.com/api/openapi.json`
+- Documentation UI: `https://your-payload.com/api/docs` (only if you enabled the doc plugin)

--- a/src/openapi/generators.ts
+++ b/src/openapi/generators.ts
@@ -18,9 +18,10 @@ import type {
 import { entityToJSONSchema } from 'payload'
 import type { SanitizedPluginOptions } from '../types.js'
 import { mapValuesAsync, visitObjectNodes } from '../utils/objects.js'
-import { filterCollections, filterGlobals } from '../utils/filtering.js'
+import { filterCollections, filterGlobals, filterFields } from '../utils/filtering.js'
 import { type ComponentType, collectionName, componentName, globalName } from './naming.js'
 import { apiKeySecurity, generateSecuritySchemes } from './securitySchemes.js'
+import { shouldIncludeOperation } from '../utils/filtering.js'
 
 const baseQueryParams: Array<OpenAPIV3.ParameterObject & OpenAPIV3_1.ParameterObject> = [
   { in: 'query', name: 'depth', schema: { type: 'number' } },
@@ -83,10 +84,19 @@ const composeRef = (
   $ref: `#/components/${type}/${componentName(type, name, options)}`,
 })
 
-const generateSchemaObject = (config: SanitizedConfig, collection: Collection): JSONSchema4 => {
+const generateSchemaObject = (config: SanitizedConfig, collection: Collection, options: SanitizedPluginOptions): JSONSchema4 => {
+  // Filter fields before generating schema
+  const filteredFields = filterFields(collection.config.fields, collection, options)
+  
+  // Create a modified collection config with filtered fields
+  const modifiedCollectionConfig = {
+    ...collection.config,
+    fields: filteredFields
+  }
+  
   const schema = entityToJSONSchema(
     config,
-    removeInterfaceNames(collection.config), // the `interfaceName` option causes `entityToJSONSchema` to add a reference to a non-existing schema
+    removeInterfaceNames(modifiedCollectionConfig), // the `interfaceName` option causes `entityToJSONSchema` to add a reference to a non-existing schema
     new Map(),
     'text',
     undefined,
@@ -117,10 +127,20 @@ const requestBodySchema = (fields: Array<Field>, schema: JSONSchema4): JSONSchem
 const generateRequestBodySchema = (
   config: SanitizedConfig,
   collection: Collection,
+  options: SanitizedPluginOptions,
 ): OpenAPIV3_1.RequestBodyObject => {
+  // Filter fields before generating schema
+  const filteredFields = filterFields(collection.config.fields, collection, options)
+  
+  // Create a modified collection config with filtered fields
+  const modifiedCollectionConfig = {
+    ...collection.config,
+    fields: filteredFields
+  }
+  
   const schema = entityToJSONSchema(
     config,
-    removeInterfaceNames(collection.config), // the `interfaceName` option causes `entityToJSONSchema` to add a reference to a non-existing schema
+    removeInterfaceNames(modifiedCollectionConfig), // the `interfaceName` option causes `entityToJSONSchema` to add a reference to a non-existing schema
     new Map(),
     'text',
     undefined,
@@ -129,14 +149,17 @@ const generateRequestBodySchema = (
     description: collectionName(collection).singular,
     content: {
       'application/json': {
-        schema: requestBodySchema(collection.config.fields, schema) as OpenAPIV3_1.SchemaObject,
+        schema: requestBodySchema(filteredFields, schema) as OpenAPIV3_1.SchemaObject,
       },
     },
   }
 }
 
-const generateQueryOperationSchemas = (collection: Collection): Record<string, JSONSchema4> => {
+const generateQueryOperationSchemas = (collection: Collection, options: SanitizedPluginOptions): Record<string, JSONSchema4> => {
   const { singular } = collectionName(collection)
+  
+  // Filter fields before generating query operations
+  const filteredFields = filterFields(collection.config.fields, collection, options)
 
   return {
     [componentName('schemas', singular, { suffix: 'QueryOperations' })]: {
@@ -144,7 +167,7 @@ const generateQueryOperationSchemas = (collection: Collection): Record<string, J
       type: 'object',
       properties: Object.fromEntries(
         (
-          collection.config.fields.filter(({ type }) =>
+          filteredFields.filter(({ type }) =>
             ['number', 'text', 'email', 'date', 'radio', 'checkbox', 'select'].includes(type),
           ) as Array<
             FieldBase & {
@@ -356,109 +379,143 @@ const isOpenToPublic = async (checker: Access): Promise<boolean> => {
 
 const generateCollectionOperations = async (
   collection: Collection,
+  options: SanitizedPluginOptions,
 ): Promise<Record<string, OpenAPIV3.PathItemObject & OpenAPIV3_1.PathItemObject>> => {
-  const { slug } = collection.config
+  const slug = collection.config.slug
   const { singular, plural } = collectionName(collection)
-  const tags = [plural]
+  const tags = [singular]
+  
+  // Filter fields for sort parameter
+  const filteredFields = filterFields(collection.config.fields, collection, options)
+
+  const listResponses = {
+    200: composeRef('responses', singular, { suffix: 'List' }),
+  } satisfies OpenAPIV3_1.ResponsesObject & OpenAPIV3.ResponsesObject
 
   const singleObjectResponses = {
     200: composeRef('responses', singular),
     404: composeRef('responses', singular, { suffix: 'NotFound' }),
   } satisfies OpenAPIV3_1.ResponsesObject & OpenAPIV3.ResponsesObject
 
-  return {
-    [`/api/${slug}`]: {
-      get: {
-        summary: `Retrieve a list of ${plural}`,
-        tags,
-        parameters: [
-          { in: 'query', name: 'page', schema: { type: 'number' } },
-          { in: 'query', name: 'limit', schema: { type: 'number' } },
-          ...baseQueryParams,
-          {
-            in: 'query',
-            name: 'sort',
-            schema: {
-              type: 'string',
-              enum: collection.config.fields.flatMap(field => {
-                if (
-                  field.type === 'number' ||
-                  field.type === 'text' ||
-                  field.type === 'email' ||
-                  field.type === 'date'
-                ) {
-                  return [field.name, `-${field.name}`]
-                }
-                return []
-              }),
-            },
-          },
-          {
-            in: 'query',
-            name: 'where',
-            style: 'deepObject',
-            schema: {
-              allOf: [
-                { type: 'object' },
-                {
-                  anyOf: [
-                    composeRef('schemas', singular, { suffix: 'QueryOperations' }),
-                    composeRef('schemas', singular, { suffix: 'QueryOperationsAnd' }),
-                    composeRef('schemas', singular, { suffix: 'QueryOperationsOr' }),
-                  ],
-                },
-              ],
-            },
-          },
-        ],
-        responses: {
-          200: composeRef('responses', singular, { suffix: 'List' }),
-        },
-        security: (await isOpenToPublic(collection.config.access.read)) ? [] : [apiKeySecurity],
-      },
-      post: {
-        summary: `Create a new ${singular}`,
-        tags,
-        requestBody: composeRef('requestBodies', singular),
-        responses: {
-          201: composeRef('responses', singular, { prefix: 'New' }),
-        },
-        security: (await isOpenToPublic(collection.config.access.create)) ? [] : [apiKeySecurity],
-      },
-    },
-    [`/api/${slug}/{id}`]: {
+  const paths: Record<string, OpenAPIV3.PathItemObject & OpenAPIV3_1.PathItemObject> = {}
+
+  // Collection-level operations (/api/{slug})
+  const collectionPath: OpenAPIV3.PathItemObject & OpenAPIV3_1.PathItemObject = {}
+
+  // List operation (GET /api/{slug})
+  if (shouldIncludeOperation('list', collection, options)) {
+    collectionPath.get = {
+      summary: `Retrieve a list of ${plural}`,
+      tags,
       parameters: [
+        { in: 'query', name: 'page', schema: { type: 'number' } },
+        { in: 'query', name: 'limit', schema: { type: 'number' } },
         ...baseQueryParams,
         {
-          in: 'path',
-          name: 'id',
-          description: `ID of the ${singular}`,
-          required: true,
+          in: 'query',
+          name: 'sort',
           schema: {
             type: 'string',
+            enum: filteredFields.flatMap(field => {
+              if (
+                field.type === 'number' ||
+                field.type === 'text' ||
+                field.type === 'email' ||
+                field.type === 'date'
+              ) {
+                return [field.name, `-${field.name}`]
+              }
+              return []
+            }),
+          },
+        },
+        {
+          in: 'query',
+          name: 'where',
+          style: 'deepObject',
+          schema: {
+            allOf: [
+              { type: 'object' },
+              {
+                anyOf: [
+                  composeRef('schemas', singular, { suffix: 'QueryOperations' }),
+                  composeRef('schemas', singular, { suffix: 'QueryOperationsAnd' }),
+                  composeRef('schemas', singular, { suffix: 'QueryOperationsOr' }),
+                ],
+              },
+            ],
           },
         },
       ],
-      get: {
-        summary: `Find a ${singular} by ID`,
-        tags,
-        responses: singleObjectResponses,
-        security: (await isOpenToPublic(collection.config.access.read)) ? [] : [apiKeySecurity],
+      responses: {
+        200: composeRef('responses', singular, { suffix: 'List' }),
       },
-      patch: {
-        summary: `Update a ${singular}`,
-        tags,
-        responses: singleObjectResponses,
-        security: (await isOpenToPublic(collection.config.access.update)) ? [] : [apiKeySecurity],
-      },
-      delete: {
-        summary: `Delete a ${singular}`,
-        tags,
-        responses: singleObjectResponses,
-        security: (await isOpenToPublic(collection.config.access.delete)) ? [] : [apiKeySecurity],
-      },
-    },
+      security: (await isOpenToPublic(collection.config.access.read)) ? [] : [apiKeySecurity],
+    }
   }
+
+  // Create operation (POST /api/{slug})
+  if (shouldIncludeOperation('create', collection, options)) {
+    collectionPath.post = {
+      summary: `Create a new ${singular}`,
+      tags,
+      requestBody: composeRef('requestBodies', singular),
+      responses: {
+        201: composeRef('responses', singular),
+      },
+      security: (await isOpenToPublic(collection.config.access.create)) ? [] : [apiKeySecurity],
+    }
+  }
+
+  if (Object.keys(collectionPath).length > 0) {
+    paths[`/api/${slug}`] = collectionPath
+  }
+
+  // Document-level operations (/api/{slug}/{id})
+  const documentPath: OpenAPIV3.PathItemObject & OpenAPIV3_1.PathItemObject = {}
+
+  // Read operation (GET /api/{slug}/{id})
+  if (shouldIncludeOperation('read', collection, options)) {
+    documentPath.get = {
+      summary: `Retrieve a specific ${singular}`,
+      tags,
+      parameters: [
+        { in: 'path', name: 'id', required: true, schema: { type: 'string' } },
+        ...baseQueryParams,
+      ],
+      responses: singleObjectResponses,
+      security: (await isOpenToPublic(collection.config.access.read)) ? [] : [apiKeySecurity],
+    }
+  }
+
+  // Update operation (PATCH /api/{slug}/{id})
+  if (shouldIncludeOperation('update', collection, options)) {
+    documentPath.patch = {
+      summary: `Update a specific ${singular}`,
+      tags,
+      parameters: [{ in: 'path', name: 'id', required: true, schema: { type: 'string' } }],
+      requestBody: composeRef('requestBodies', singular),
+      responses: singleObjectResponses,
+      security: (await isOpenToPublic(collection.config.access.update)) ? [] : [apiKeySecurity],
+    }
+  }
+
+  // Delete operation (DELETE /api/{slug}/{id})
+  if (shouldIncludeOperation('delete', collection, options)) {
+    documentPath.delete = {
+      summary: `Delete a specific ${singular}`,
+      tags,
+      parameters: [{ in: 'path', name: 'id', required: true, schema: { type: 'string' } }],
+      responses: singleObjectResponses,
+      security: (await isOpenToPublic(collection.config.access.delete)) ? [] : [apiKeySecurity],
+    }
+  }
+
+  if (Object.keys(documentPath).length > 0) {
+    paths[`/api/${slug}/{id}`] = documentPath
+  }
+
+  return paths
 }
 
 const generateGlobalResponse = (
@@ -537,16 +594,17 @@ const generateGlobalOperations = async (
   }
 }
 
-const generateComponents = (
+const generateComponents = async (
   req: Pick<PayloadRequest, 'payload'>,
-  options: SanitizedPluginOptions
-) => {
-  const schemas: Record<string, JSONSchema4> = {
-    supportedTimezones: {
-      type: 'string',
-      example: 'Europe/Prague',
-    },
-  }
+  options: SanitizedPluginOptions,
+): Promise<{
+  schemas: Record<string, JSONSchema4>
+  requestBodies: Record<string, OpenAPIV3_1.RequestBodyObject>
+  responses: Record<string, OpenAPIV3_1.ResponseObject>
+  filteredCollections: Collection[]
+  filteredGlobals: SanitizedGlobalConfig[]
+}> => {
+  const schemas: Record<string, JSONSchema4> = {}
 
   // Filter collections and globals based on options
   const filteredCollections = filterCollections(req.payload.collections, options)
@@ -557,11 +615,12 @@ const generateComponents = (
     schemas[componentName('schemas', singular)] = generateSchemaObject(
       req.payload.config,
       collection,
+      options,
     )
   }
 
   for (const collection of filteredCollections) {
-    Object.assign(schemas, generateQueryOperationSchemas(collection))
+    Object.assign(schemas, generateQueryOperationSchemas(collection, options))
   }
 
   for (const global of filteredGlobals) {
@@ -575,6 +634,7 @@ const generateComponents = (
     requestBodies[componentName('requestBodies', singular)] = generateRequestBodySchema(
       req.payload.config,
       collection,
+      options,
     )
   }
 
@@ -598,7 +658,7 @@ export const generateV30Spec = async (
   req: Pick<PayloadRequest, 'payload' | 'protocol' | 'headers'>,
   options: SanitizedPluginOptions,
 ): Promise<OpenAPIV3.Document> => {
-  const { schemas, requestBodies, responses, filteredCollections, filteredGlobals } = generateComponents(req, options)
+  const { schemas, requestBodies, responses, filteredCollections, filteredGlobals } = await generateComponents(req, options)
 
   const spec = {
     openapi: '3.0.3',
@@ -607,7 +667,7 @@ export const generateV30Spec = async (
     paths: Object.assign(
       {},
       ...(await Promise.all(
-        filteredCollections.map(generateCollectionOperations),
+        filteredCollections.map(collection => generateCollectionOperations(collection, options)),
       )),
       ...(await Promise.all(filteredGlobals.map(generateGlobalOperations))),
     ),
@@ -658,7 +718,7 @@ export const generateV31Spec = async (
   req: Pick<PayloadRequest, 'payload' | 'protocol' | 'headers'>,
   options: SanitizedPluginOptions,
 ): Promise<OpenAPIV3_1.Document> => {
-  const { schemas, requestBodies, responses, filteredCollections, filteredGlobals } = generateComponents(req, options)
+  const { schemas, requestBodies, responses, filteredCollections, filteredGlobals } = await generateComponents(req, options)
 
   const spec = {
     openapi: '3.1.0',
@@ -666,8 +726,10 @@ export const generateV31Spec = async (
     servers: [{ url: `${req.protocol}//${req.headers.get('host')}` }],
     paths: Object.assign(
       {},
-      ...filteredCollections.map(generateCollectionOperations),
-      ...filteredGlobals.map(generateGlobalOperations),
+      ...(await Promise.all(
+        filteredCollections.map(collection => generateCollectionOperations(collection, options)),
+      )),
+      ...(await Promise.all(filteredGlobals.map(generateGlobalOperations))),
     ),
     components: {
       securitySchemes: generateSecuritySchemes(options.authEndpoint),

--- a/src/openapiPlugin.ts
+++ b/src/openapiPlugin.ts
@@ -10,6 +10,10 @@ const openapi =
     openapiVersion = '3.0',
     metadata,
     enabled = true,
+    includeCollections,
+    excludeCollections,
+    includeGlobals,
+    excludeGlobals,
   }: PluginOptions): Plugin =>
   ({ endpoints = [], ...config }) => {
     if (!enabled) {
@@ -27,6 +31,10 @@ const openapi =
             openapiVersion,
             metadata,
             authEndpoint,
+            includeCollections,
+            excludeCollections,
+            includeGlobals,
+            excludeGlobals,
           }),
         },
         {

--- a/src/openapiPlugin.ts
+++ b/src/openapiPlugin.ts
@@ -14,6 +14,9 @@ const openapi =
     excludeCollections,
     includeGlobals,
     excludeGlobals,
+    operations,
+    excludeFields,
+    hideInternalCollections,
   }: PluginOptions): Plugin =>
   ({ endpoints = [], ...config }) => {
     if (!enabled) {
@@ -35,6 +38,9 @@ const openapi =
             excludeCollections,
             includeGlobals,
             excludeGlobals,
+            operations,
+            excludeFields,
+            hideInternalCollections,
           }),
         },
         {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,16 @@ export interface OpenAPIMetadata {
 
 export type FilterFunction<T> = (item: T) => boolean
 
+export type CRUDOperation = 'create' | 'read' | 'update' | 'delete' | 'list'
+
+export interface OperationFilter {
+  // Include/exclude specific operations for collections
+  includeOperations?: CRUDOperation[]
+  excludeOperations?: CRUDOperation[]
+  // Custom operation filter per collection
+  operationFilter?: (operation: CRUDOperation, collection: { slug: string; config: any }) => boolean
+}
+
 export interface PluginOptions {
   enabled?: boolean
   openapiVersion?: OpenAPIVersion
@@ -20,11 +30,20 @@ export interface PluginOptions {
   // Global filtering options
   includeGlobals?: string[] | FilterFunction<{ slug: string }>
   excludeGlobals?: string[] | FilterFunction<{ slug: string }>
+  // Operation-level filtering
+  operations?: OperationFilter
+  // Field-level filtering
+  excludeFields?: string[] | FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>
+  // Hide internal collections
+  hideInternalCollections?: boolean // Hide payload-* collections
 }
 
-export type SanitizedPluginOptions = Required<Omit<PluginOptions, 'enabled' | 'specEndpoint' | 'includeCollections' | 'excludeCollections' | 'includeGlobals' | 'excludeGlobals'>> & {
+export type SanitizedPluginOptions = Required<Omit<PluginOptions, 'enabled' | 'specEndpoint' | 'includeCollections' | 'excludeCollections' | 'includeGlobals' | 'excludeGlobals' | 'operations' | 'excludeFields' | 'hideInternalCollections'>> & {
   includeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
   excludeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
   includeGlobals?: string[] | FilterFunction<{ slug: string }>
   excludeGlobals?: string[] | FilterFunction<{ slug: string }>
+  operations?: OperationFilter
+  excludeFields?: string[] | FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>
+  hideInternalCollections?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,12 +6,25 @@ export interface OpenAPIMetadata {
   description?: string
 }
 
+export type FilterFunction<T> = (item: T) => boolean
+
 export interface PluginOptions {
   enabled?: boolean
   openapiVersion?: OpenAPIVersion
   specEndpoint?: string
   authEndpoint?: string
   metadata: OpenAPIMetadata
+  // Collection filtering options
+  includeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
+  excludeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
+  // Global filtering options
+  includeGlobals?: string[] | FilterFunction<{ slug: string }>
+  excludeGlobals?: string[] | FilterFunction<{ slug: string }>
 }
 
-export type SanitizedPluginOptions = Required<Omit<PluginOptions, 'enabled' | 'specEndpoint'>>
+export type SanitizedPluginOptions = Required<Omit<PluginOptions, 'enabled' | 'specEndpoint' | 'includeCollections' | 'excludeCollections' | 'includeGlobals' | 'excludeGlobals'>> & {
+  includeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
+  excludeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
+  includeGlobals?: string[] | FilterFunction<{ slug: string }>
+  excludeGlobals?: string[] | FilterFunction<{ slug: string }>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,17 +33,34 @@ export interface PluginOptions {
   // Operation-level filtering
   operations?: OperationFilter
   // Field-level filtering
-  excludeFields?: string[] | FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>
+  excludeFields?:
+    | string[]
+    | FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>
   // Hide internal collections
   hideInternalCollections?: boolean // Hide payload-* collections
 }
 
-export type SanitizedPluginOptions = Required<Omit<PluginOptions, 'enabled' | 'specEndpoint' | 'includeCollections' | 'excludeCollections' | 'includeGlobals' | 'excludeGlobals' | 'operations' | 'excludeFields' | 'hideInternalCollections'>> & {
+export type SanitizedPluginOptions = Required<
+  Omit<
+    PluginOptions,
+    | 'enabled'
+    | 'specEndpoint'
+    | 'includeCollections'
+    | 'excludeCollections'
+    | 'includeGlobals'
+    | 'excludeGlobals'
+    | 'operations'
+    | 'excludeFields'
+    | 'hideInternalCollections'
+  >
+> & {
   includeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
   excludeCollections?: string[] | FilterFunction<{ slug: string; config: any }>
   includeGlobals?: string[] | FilterFunction<{ slug: string }>
   excludeGlobals?: string[] | FilterFunction<{ slug: string }>
   operations?: OperationFilter
-  excludeFields?: string[] | FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>
+  excludeFields?:
+    | string[]
+    | FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>
   hideInternalCollections?: boolean
 }

--- a/src/utils/filtering.ts
+++ b/src/utils/filtering.ts
@@ -1,21 +1,24 @@
-import type { Collection, SanitizedGlobalConfig, Field } from 'payload'
-import type { FilterFunction, SanitizedPluginOptions, CRUDOperation } from '../types.js'
+import type { Collection, Field, SanitizedGlobalConfig } from 'payload'
+import type { CRUDOperation, FilterFunction, SanitizedPluginOptions } from '../types.js'
 
 /**
  * Filters collections based on include/exclude options
  */
 export function filterCollections(
   collections: Record<string, Collection>,
-  options: Pick<SanitizedPluginOptions, 'includeCollections' | 'excludeCollections' | 'hideInternalCollections'>
+  options: Pick<
+    SanitizedPluginOptions,
+    'includeCollections' | 'excludeCollections' | 'hideInternalCollections'
+  >,
 ): Collection[] {
   const allCollections = Object.values(collections)
-  
+
   let filteredCollections = allCollections
 
   // Hide internal Payload collections
   if (options.hideInternalCollections) {
-    filteredCollections = filteredCollections.filter(collection =>
-      !collection.config.slug.startsWith('payload-')
+    filteredCollections = filteredCollections.filter(
+      collection => !collection.config.slug.startsWith('payload-'),
     )
   }
 
@@ -23,14 +26,14 @@ export function filterCollections(
   if (options.includeCollections) {
     if (Array.isArray(options.includeCollections)) {
       filteredCollections = filteredCollections.filter(collection =>
-        (options.includeCollections as string[]).includes(collection.config.slug)
+        (options.includeCollections as string[]).includes(collection.config.slug),
       )
     } else {
       filteredCollections = filteredCollections.filter(collection =>
         (options.includeCollections as FilterFunction<{ slug: string; config: any }>)({
           slug: collection.config.slug,
-          config: collection.config
-        })
+          config: collection.config,
+        }),
       )
     }
   }
@@ -38,15 +41,16 @@ export function filterCollections(
   // Apply exclude filter
   if (options.excludeCollections) {
     if (Array.isArray(options.excludeCollections)) {
-      filteredCollections = filteredCollections.filter(collection =>
-        !(options.excludeCollections as string[]).includes(collection.config.slug)
+      filteredCollections = filteredCollections.filter(
+        collection => !(options.excludeCollections as string[]).includes(collection.config.slug),
       )
     } else {
-      filteredCollections = filteredCollections.filter(collection =>
-        !(options.excludeCollections as FilterFunction<{ slug: string; config: any }>)({
-          slug: collection.config.slug,
-          config: collection.config
-        })
+      filteredCollections = filteredCollections.filter(
+        collection =>
+          !(options.excludeCollections as FilterFunction<{ slug: string; config: any }>)({
+            slug: collection.config.slug,
+            config: collection.config,
+          }),
       )
     }
   }
@@ -59,7 +63,7 @@ export function filterCollections(
  */
 export function filterGlobals(
   globals: SanitizedGlobalConfig[],
-  options: Pick<SanitizedPluginOptions, 'includeGlobals' | 'excludeGlobals'>
+  options: Pick<SanitizedPluginOptions, 'includeGlobals' | 'excludeGlobals'>,
 ): SanitizedGlobalConfig[] {
   let filteredGlobals = globals
 
@@ -67,13 +71,13 @@ export function filterGlobals(
   if (options.includeGlobals) {
     if (Array.isArray(options.includeGlobals)) {
       filteredGlobals = filteredGlobals.filter(global =>
-        (options.includeGlobals as string[]).includes(global.slug)
+        (options.includeGlobals as string[]).includes(global.slug),
       )
     } else {
       filteredGlobals = filteredGlobals.filter(global =>
         (options.includeGlobals as FilterFunction<{ slug: string }>)({
-          slug: global.slug
-        })
+          slug: global.slug,
+        }),
       )
     }
   }
@@ -81,14 +85,15 @@ export function filterGlobals(
   // Apply exclude filter
   if (options.excludeGlobals) {
     if (Array.isArray(options.excludeGlobals)) {
-      filteredGlobals = filteredGlobals.filter(global =>
-        !(options.excludeGlobals as string[]).includes(global.slug)
+      filteredGlobals = filteredGlobals.filter(
+        global => !(options.excludeGlobals as string[]).includes(global.slug),
       )
     } else {
-      filteredGlobals = filteredGlobals.filter(global =>
-        !(options.excludeGlobals as FilterFunction<{ slug: string }>)({
-          slug: global.slug
-        })
+      filteredGlobals = filteredGlobals.filter(
+        global =>
+          !(options.excludeGlobals as FilterFunction<{ slug: string }>)({
+            slug: global.slug,
+          }),
       )
     }
   }
@@ -102,7 +107,7 @@ export function filterGlobals(
 export function shouldIncludeOperation(
   operation: CRUDOperation,
   collection: Collection,
-  options: Pick<SanitizedPluginOptions, 'operations'>
+  options: Pick<SanitizedPluginOptions, 'operations'>,
 ): boolean {
   if (!options.operations) return true
 
@@ -112,7 +117,7 @@ export function shouldIncludeOperation(
   if (operationFilter) {
     return operationFilter(operation, {
       slug: collection.config.slug,
-      config: collection.config
+      config: collection.config,
     })
   }
 
@@ -122,7 +127,7 @@ export function shouldIncludeOperation(
   }
 
   // Apply exclude filter
-  if (excludeOperations && excludeOperations.includes(operation)) {
+  if (excludeOperations?.includes(operation)) {
     return false
   }
 
@@ -135,7 +140,7 @@ export function shouldIncludeOperation(
 export function filterFields(
   fields: Field[],
   collection: Collection,
-  options: Pick<SanitizedPluginOptions, 'excludeFields'>
+  options: Pick<SanitizedPluginOptions, 'excludeFields'>,
 ): Field[] {
   let filteredFields = fields
 
@@ -151,18 +156,24 @@ export function filterFields(
         const fieldName = (field as any).name
         const fieldType = field.type
         if (!fieldName) return true
-        
-        return !(options.excludeFields as FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>)({
+
+        return !(
+          options.excludeFields as FilterFunction<{
+            name: string
+            type: string
+            collection: { slug: string; config: any }
+          }>
+        )({
           name: fieldName,
           type: fieldType,
           collection: {
             slug: collection.config.slug,
-            config: collection.config
-          }
+            config: collection.config,
+          },
         })
       })
     }
   }
 
   return filteredFields
-} 
+}

--- a/src/utils/filtering.ts
+++ b/src/utils/filtering.ts
@@ -1,16 +1,23 @@
-import type { Collection, SanitizedGlobalConfig } from 'payload'
-import type { FilterFunction, SanitizedPluginOptions } from '../types.js'
+import type { Collection, SanitizedGlobalConfig, Field } from 'payload'
+import type { FilterFunction, SanitizedPluginOptions, CRUDOperation } from '../types.js'
 
 /**
  * Filters collections based on include/exclude options
  */
 export function filterCollections(
   collections: Record<string, Collection>,
-  options: Pick<SanitizedPluginOptions, 'includeCollections' | 'excludeCollections'>
+  options: Pick<SanitizedPluginOptions, 'includeCollections' | 'excludeCollections' | 'hideInternalCollections'>
 ): Collection[] {
   const allCollections = Object.values(collections)
   
   let filteredCollections = allCollections
+
+  // Hide internal Payload collections
+  if (options.hideInternalCollections) {
+    filteredCollections = filteredCollections.filter(collection =>
+      !collection.config.slug.startsWith('payload-')
+    )
+  }
 
   // Apply include filter first
   if (options.includeCollections) {
@@ -87,4 +94,75 @@ export function filterGlobals(
   }
 
   return filteredGlobals
+}
+
+/**
+ * Checks if a specific operation should be included for a collection
+ */
+export function shouldIncludeOperation(
+  operation: CRUDOperation,
+  collection: Collection,
+  options: Pick<SanitizedPluginOptions, 'operations'>
+): boolean {
+  if (!options.operations) return true
+
+  const { includeOperations, excludeOperations, operationFilter } = options.operations
+
+  // Apply custom operation filter first
+  if (operationFilter) {
+    return operationFilter(operation, {
+      slug: collection.config.slug,
+      config: collection.config
+    })
+  }
+
+  // Apply include filter
+  if (includeOperations && !includeOperations.includes(operation)) {
+    return false
+  }
+
+  // Apply exclude filter
+  if (excludeOperations && excludeOperations.includes(operation)) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Filters fields based on options
+ */
+export function filterFields(
+  fields: Field[],
+  collection: Collection,
+  options: Pick<SanitizedPluginOptions, 'excludeFields'>
+): Field[] {
+  let filteredFields = fields
+
+  // Apply exclude filter
+  if (options.excludeFields) {
+    if (Array.isArray(options.excludeFields)) {
+      filteredFields = filteredFields.filter(field => {
+        const fieldName = (field as any).name
+        return !fieldName || !(options.excludeFields as string[]).includes(fieldName)
+      })
+    } else {
+      filteredFields = filteredFields.filter(field => {
+        const fieldName = (field as any).name
+        const fieldType = field.type
+        if (!fieldName) return true
+        
+        return !(options.excludeFields as FilterFunction<{ name: string; type: string; collection: { slug: string; config: any } }>)({
+          name: fieldName,
+          type: fieldType,
+          collection: {
+            slug: collection.config.slug,
+            config: collection.config
+          }
+        })
+      })
+    }
+  }
+
+  return filteredFields
 } 

--- a/src/utils/filtering.ts
+++ b/src/utils/filtering.ts
@@ -1,0 +1,90 @@
+import type { Collection, SanitizedGlobalConfig } from 'payload'
+import type { FilterFunction, SanitizedPluginOptions } from '../types.js'
+
+/**
+ * Filters collections based on include/exclude options
+ */
+export function filterCollections(
+  collections: Record<string, Collection>,
+  options: Pick<SanitizedPluginOptions, 'includeCollections' | 'excludeCollections'>
+): Collection[] {
+  const allCollections = Object.values(collections)
+  
+  let filteredCollections = allCollections
+
+  // Apply include filter first
+  if (options.includeCollections) {
+    if (Array.isArray(options.includeCollections)) {
+      filteredCollections = filteredCollections.filter(collection =>
+        (options.includeCollections as string[]).includes(collection.config.slug)
+      )
+    } else {
+      filteredCollections = filteredCollections.filter(collection =>
+        (options.includeCollections as FilterFunction<{ slug: string; config: any }>)({
+          slug: collection.config.slug,
+          config: collection.config
+        })
+      )
+    }
+  }
+
+  // Apply exclude filter
+  if (options.excludeCollections) {
+    if (Array.isArray(options.excludeCollections)) {
+      filteredCollections = filteredCollections.filter(collection =>
+        !(options.excludeCollections as string[]).includes(collection.config.slug)
+      )
+    } else {
+      filteredCollections = filteredCollections.filter(collection =>
+        !(options.excludeCollections as FilterFunction<{ slug: string; config: any }>)({
+          slug: collection.config.slug,
+          config: collection.config
+        })
+      )
+    }
+  }
+
+  return filteredCollections
+}
+
+/**
+ * Filters globals based on include/exclude options
+ */
+export function filterGlobals(
+  globals: SanitizedGlobalConfig[],
+  options: Pick<SanitizedPluginOptions, 'includeGlobals' | 'excludeGlobals'>
+): SanitizedGlobalConfig[] {
+  let filteredGlobals = globals
+
+  // Apply include filter first
+  if (options.includeGlobals) {
+    if (Array.isArray(options.includeGlobals)) {
+      filteredGlobals = filteredGlobals.filter(global =>
+        (options.includeGlobals as string[]).includes(global.slug)
+      )
+    } else {
+      filteredGlobals = filteredGlobals.filter(global =>
+        (options.includeGlobals as FilterFunction<{ slug: string }>)({
+          slug: global.slug
+        })
+      )
+    }
+  }
+
+  // Apply exclude filter
+  if (options.excludeGlobals) {
+    if (Array.isArray(options.excludeGlobals)) {
+      filteredGlobals = filteredGlobals.filter(global =>
+        !(options.excludeGlobals as string[]).includes(global.slug)
+      )
+    } else {
+      filteredGlobals = filteredGlobals.filter(global =>
+        !(options.excludeGlobals as FilterFunction<{ slug: string }>)({
+          slug: global.slug
+        })
+      )
+    }
+  }
+
+  return filteredGlobals
+} 

--- a/test/__snapshots__/openapi-generators.test.ts.snap
+++ b/test/__snapshots__/openapi-generators.test.ts.snap
@@ -1683,10 +1683,6 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         "title": "users query disjunction",
         "type": "object",
       },
-      "supportedTimezones": {
-        "example": "Europe/Prague",
-        "type": "string",
-      },
     },
     "securitySchemes": {
       "ApiKey": {
@@ -1797,7 +1793,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Locked Documents",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "post": {
@@ -1806,7 +1802,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadLockedDocumentResponse",
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
           },
         },
         "security": [
@@ -1816,12 +1812,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
         "summary": "Create a new Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
     "/api/payload-locked-documents/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -1835,12 +1841,43 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Locked Document",
+        "summary": "Delete a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -1854,44 +1891,25 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Locked Document by ID",
+        "summary": "Retrieve a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Locked Document",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -1905,9 +1923,9 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Locked Document",
+        "summary": "Update a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
@@ -2004,7 +2022,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Migrations",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "post": {
@@ -2013,7 +2031,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadMigrationResponse",
+            "$ref": "#/components/responses/PayloadMigrationResponse",
           },
         },
         "security": [
@@ -2023,12 +2041,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
         "summary": "Create a new Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
     "/api/payload-migrations/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -2042,12 +2070,43 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Migration",
+        "summary": "Delete a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -2061,44 +2120,25 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Migration by ID",
+        "summary": "Retrieve a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Migration",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -2112,9 +2152,9 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Migration",
+        "summary": "Update a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
@@ -2209,7 +2249,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Preferences",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "post": {
@@ -2218,7 +2258,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadPreferenceResponse",
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
           },
         },
         "security": [
@@ -2228,12 +2268,22 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         ],
         "summary": "Create a new Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
     "/api/payload-preferences/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -2247,12 +2297,43 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Preference",
+        "summary": "Delete a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -2266,44 +2347,25 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Preference by ID",
+        "summary": "Retrieve a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Preference",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -2317,9 +2379,9 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Preference",
+        "summary": "Update a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
@@ -2435,7 +2497,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewUsersResponse",
+            "$ref": "#/components/responses/UsersResponse",
           },
         },
         "security": [
@@ -2451,6 +2513,16 @@ exports[`openapi generators > converts empty config correctly 1`] = `
     },
     "/api/users/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -2464,12 +2536,43 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a users",
+        "summary": "Delete a specific users",
         "tags": [
           "users",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -2483,44 +2586,25 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a users by ID",
+        "summary": "Retrieve a specific users",
         "tags": [
           "users",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the users",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UsersRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -2534,7 +2618,7 @@ exports[`openapi generators > converts empty config correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a users",
+        "summary": "Update a specific users",
         "tags": [
           "users",
         ],
@@ -4752,10 +4836,6 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         "title": "users query disjunction",
         "type": "object",
       },
-      "supportedTimezones": {
-        "example": "Europe/Prague",
-        "type": "string",
-      },
     },
     "securitySchemes": {
       "ApiKey": {
@@ -4864,7 +4944,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Retrieve a list of Pages",
         "tags": [
-          "Pages",
+          "Page",
         ],
       },
       "post": {
@@ -4873,7 +4953,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPageResponse",
+            "$ref": "#/components/responses/PageResponse",
           },
         },
         "security": [
@@ -4883,12 +4963,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Create a new Page",
         "tags": [
-          "Pages",
+          "Page",
         ],
       },
     },
     "/api/pages/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PageResponse",
@@ -4902,12 +4992,43 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Page",
+        "summary": "Delete a specific Page",
         "tags": [
-          "Pages",
+          "Page",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PageResponse",
@@ -4921,44 +5042,25 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Page by ID",
+        "summary": "Retrieve a specific Page",
         "tags": [
-          "Pages",
+          "Page",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Page",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PageRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PageResponse",
@@ -4972,9 +5074,9 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Page",
+        "summary": "Update a specific Page",
         "tags": [
-          "Pages",
+          "Page",
         ],
       },
     },
@@ -5069,7 +5171,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Locked Documents",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "post": {
@@ -5078,7 +5180,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadLockedDocumentResponse",
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
           },
         },
         "security": [
@@ -5088,12 +5190,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Create a new Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
     "/api/payload-locked-documents/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -5107,12 +5219,43 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Locked Document",
+        "summary": "Delete a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -5126,44 +5269,25 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Locked Document by ID",
+        "summary": "Retrieve a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Locked Document",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -5177,9 +5301,9 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Locked Document",
+        "summary": "Update a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
@@ -5276,7 +5400,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Migrations",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "post": {
@@ -5285,7 +5409,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadMigrationResponse",
+            "$ref": "#/components/responses/PayloadMigrationResponse",
           },
         },
         "security": [
@@ -5295,12 +5419,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Create a new Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
     "/api/payload-migrations/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -5314,12 +5448,43 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Migration",
+        "summary": "Delete a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -5333,44 +5498,25 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Migration by ID",
+        "summary": "Retrieve a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Migration",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -5384,9 +5530,9 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Migration",
+        "summary": "Update a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
@@ -5481,7 +5627,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Preferences",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "post": {
@@ -5490,7 +5636,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadPreferenceResponse",
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
           },
         },
         "security": [
@@ -5500,12 +5646,22 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         ],
         "summary": "Create a new Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
     "/api/payload-preferences/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -5519,12 +5675,43 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Preference",
+        "summary": "Delete a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -5538,44 +5725,25 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Preference by ID",
+        "summary": "Retrieve a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Preference",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -5589,9 +5757,9 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Preference",
+        "summary": "Update a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
@@ -5707,7 +5875,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewUsersResponse",
+            "$ref": "#/components/responses/UsersResponse",
           },
         },
         "security": [
@@ -5723,6 +5891,16 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
     },
     "/api/users/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -5736,12 +5914,43 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a users",
+        "summary": "Delete a specific users",
         "tags": [
           "users",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -5755,44 +5964,25 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a users by ID",
+        "summary": "Retrieve a specific users",
         "tags": [
           "users",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the users",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UsersRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -5806,7 +5996,7 @@ exports[`openapi generators > handles block editor fields correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a users",
+        "summary": "Update a specific users",
         "tags": [
           "users",
         ],
@@ -7978,10 +8168,6 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         "title": "users query disjunction",
         "type": "object",
       },
-      "supportedTimezones": {
-        "example": "Europe/Prague",
-        "type": "string",
-      },
     },
     "securitySchemes": {
       "ApiKey": {
@@ -8092,7 +8278,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Retrieve a list of Events",
         "tags": [
-          "Events",
+          "Event",
         ],
       },
       "post": {
@@ -8101,7 +8287,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewEventResponse",
+            "$ref": "#/components/responses/EventResponse",
           },
         },
         "security": [
@@ -8111,12 +8297,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Create a new Event",
         "tags": [
-          "Events",
+          "Event",
         ],
       },
     },
     "/api/events/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/EventResponse",
@@ -8130,12 +8326,43 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Event",
+        "summary": "Delete a specific Event",
         "tags": [
-          "Events",
+          "Event",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/EventResponse",
@@ -8149,44 +8376,25 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Event by ID",
+        "summary": "Retrieve a specific Event",
         "tags": [
-          "Events",
+          "Event",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Event",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/EventRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/EventResponse",
@@ -8200,9 +8408,9 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Event",
+        "summary": "Update a specific Event",
         "tags": [
-          "Events",
+          "Event",
         ],
       },
     },
@@ -8297,7 +8505,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Retrieve a list of Payload Locked Documents",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "post": {
@@ -8306,7 +8514,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadLockedDocumentResponse",
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
           },
         },
         "security": [
@@ -8316,12 +8524,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Create a new Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
     "/api/payload-locked-documents/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -8335,12 +8553,43 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Locked Document",
+        "summary": "Delete a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -8354,44 +8603,25 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Locked Document by ID",
+        "summary": "Retrieve a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Locked Document",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -8405,9 +8635,9 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Locked Document",
+        "summary": "Update a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
@@ -8504,7 +8734,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Retrieve a list of Payload Migrations",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "post": {
@@ -8513,7 +8743,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadMigrationResponse",
+            "$ref": "#/components/responses/PayloadMigrationResponse",
           },
         },
         "security": [
@@ -8523,12 +8753,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Create a new Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
     "/api/payload-migrations/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -8542,12 +8782,43 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Migration",
+        "summary": "Delete a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -8561,44 +8832,25 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Migration by ID",
+        "summary": "Retrieve a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Migration",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -8612,9 +8864,9 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Migration",
+        "summary": "Update a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
@@ -8709,7 +8961,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Retrieve a list of Payload Preferences",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "post": {
@@ -8718,7 +8970,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadPreferenceResponse",
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
           },
         },
         "security": [
@@ -8728,12 +8980,22 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         ],
         "summary": "Create a new Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
     "/api/payload-preferences/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -8747,12 +9009,43 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Preference",
+        "summary": "Delete a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -8766,44 +9059,25 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Preference by ID",
+        "summary": "Retrieve a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Preference",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -8817,9 +9091,9 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Preference",
+        "summary": "Update a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
@@ -8935,7 +9209,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewUsersResponse",
+            "$ref": "#/components/responses/UsersResponse",
           },
         },
         "security": [
@@ -8951,6 +9225,16 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
     },
     "/api/users/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -8964,12 +9248,43 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a users",
+        "summary": "Delete a specific users",
         "tags": [
           "users",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -8983,44 +9298,25 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Find a users by ID",
+        "summary": "Retrieve a specific users",
         "tags": [
           "users",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the users",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UsersRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -9034,7 +9330,7 @@ exports[`openapi generators > handles datetime field with timezones correctly 1`
             "ApiKey": [],
           },
         ],
-        "summary": "Update a users",
+        "summary": "Update a specific users",
         "tags": [
           "users",
         ],
@@ -10770,10 +11066,6 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         "title": "User query disjunction",
         "type": "object",
       },
-      "supportedTimezones": {
-        "example": "Europe/Prague",
-        "type": "string",
-      },
     },
     "securitySchemes": {
       "ApiKey": {
@@ -10884,7 +11176,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Locked Documents",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "post": {
@@ -10893,7 +11185,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadLockedDocumentResponse",
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
           },
         },
         "security": [
@@ -10903,12 +11195,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Create a new Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
     "/api/payload-locked-documents/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -10922,12 +11224,43 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Locked Document",
+        "summary": "Delete a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -10941,44 +11274,25 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Locked Document by ID",
+        "summary": "Retrieve a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Locked Document",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -10992,9 +11306,9 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Locked Document",
+        "summary": "Update a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
@@ -11091,7 +11405,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Migrations",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "post": {
@@ -11100,7 +11414,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadMigrationResponse",
+            "$ref": "#/components/responses/PayloadMigrationResponse",
           },
         },
         "security": [
@@ -11110,12 +11424,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Create a new Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
     "/api/payload-migrations/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -11129,12 +11453,43 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Migration",
+        "summary": "Delete a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -11148,44 +11503,25 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Migration by ID",
+        "summary": "Retrieve a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Migration",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -11199,9 +11535,9 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Migration",
+        "summary": "Update a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
@@ -11296,7 +11632,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Retrieve a list of Payload Preferences",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "post": {
@@ -11305,7 +11641,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadPreferenceResponse",
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
           },
         },
         "security": [
@@ -11315,12 +11651,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Create a new Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
     "/api/payload-preferences/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -11334,12 +11680,43 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Preference",
+        "summary": "Delete a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -11353,44 +11730,25 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Preference by ID",
+        "summary": "Retrieve a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Preference",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -11404,9 +11762,9 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Preference",
+        "summary": "Update a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
@@ -11513,7 +11871,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Retrieve a list of Users",
         "tags": [
-          "Users",
+          "User",
         ],
       },
       "post": {
@@ -11522,7 +11880,7 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewUserResponse",
+            "$ref": "#/components/responses/UserResponse",
           },
         },
         "security": [
@@ -11532,12 +11890,22 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
         ],
         "summary": "Create a new User",
         "tags": [
-          "Users",
+          "User",
         ],
       },
     },
     "/api/users/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UserResponse",
@@ -11551,12 +11919,43 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a User",
+        "summary": "Delete a specific User",
         "tags": [
-          "Users",
+          "User",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UserResponse",
@@ -11570,44 +11969,25 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a User by ID",
+        "summary": "Retrieve a specific User",
         "tags": [
-          "Users",
+          "User",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the User",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/UserResponse",
@@ -11621,9 +12001,9 @@ exports[`openapi generators > handles interfaceName correctly 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a User",
+        "summary": "Update a specific User",
         "tags": [
-          "Users",
+          "User",
         ],
       },
     },
@@ -13662,10 +14042,6 @@ exports[`openapi generators > handles non-default collection 1`] = `
         "title": "users query disjunction",
         "type": "object",
       },
-      "supportedTimezones": {
-        "example": "Europe/Prague",
-        "type": "string",
-      },
     },
     "securitySchemes": {
       "ApiKey": {
@@ -13776,7 +14152,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Retrieve a list of Payload Locked Documents",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "post": {
@@ -13785,7 +14161,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadLockedDocumentResponse",
+            "$ref": "#/components/responses/PayloadLockedDocumentResponse",
           },
         },
         "security": [
@@ -13795,12 +14171,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Create a new Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
     "/api/payload-locked-documents/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -13814,12 +14200,43 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Locked Document",
+        "summary": "Delete a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -13833,44 +14250,25 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Locked Document by ID",
+        "summary": "Retrieve a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Locked Document",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadLockedDocumentRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadLockedDocumentResponse",
@@ -13884,9 +14282,9 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Locked Document",
+        "summary": "Update a specific Payload Locked Document",
         "tags": [
-          "Payload Locked Documents",
+          "Payload Locked Document",
         ],
       },
     },
@@ -13983,7 +14381,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Retrieve a list of Payload Migrations",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "post": {
@@ -13992,7 +14390,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadMigrationResponse",
+            "$ref": "#/components/responses/PayloadMigrationResponse",
           },
         },
         "security": [
@@ -14002,12 +14400,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Create a new Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
     "/api/payload-migrations/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -14021,12 +14429,43 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Migration",
+        "summary": "Delete a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -14040,44 +14479,25 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Migration by ID",
+        "summary": "Retrieve a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Migration",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadMigrationRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadMigrationResponse",
@@ -14091,9 +14511,9 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Migration",
+        "summary": "Update a specific Payload Migration",
         "tags": [
-          "Payload Migrations",
+          "Payload Migration",
         ],
       },
     },
@@ -14188,7 +14608,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Retrieve a list of Payload Preferences",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "post": {
@@ -14197,7 +14617,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPayloadPreferenceResponse",
+            "$ref": "#/components/responses/PayloadPreferenceResponse",
           },
         },
         "security": [
@@ -14207,12 +14627,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Create a new Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
     "/api/payload-preferences/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -14226,12 +14656,43 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Payload Preference",
+        "summary": "Delete a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -14245,44 +14706,25 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Payload Preference by ID",
+        "summary": "Retrieve a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Payload Preference",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PayloadPreferenceRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PayloadPreferenceResponse",
@@ -14296,9 +14738,9 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Payload Preference",
+        "summary": "Update a specific Payload Preference",
         "tags": [
-          "Payload Preferences",
+          "Payload Preference",
         ],
       },
     },
@@ -14393,7 +14835,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Retrieve a list of Posts",
         "tags": [
-          "Posts",
+          "Post",
         ],
       },
       "post": {
@@ -14402,7 +14844,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewPostResponse",
+            "$ref": "#/components/responses/PostResponse",
           },
         },
         "security": [
@@ -14412,12 +14854,22 @@ exports[`openapi generators > handles non-default collection 1`] = `
         ],
         "summary": "Create a new Post",
         "tags": [
-          "Posts",
+          "Post",
         ],
       },
     },
     "/api/posts/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PostResponse",
@@ -14431,12 +14883,43 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a Post",
+        "summary": "Delete a specific Post",
         "tags": [
-          "Posts",
+          "Post",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/PostResponse",
@@ -14450,44 +14933,25 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a Post by ID",
+        "summary": "Retrieve a specific Post",
         "tags": [
-          "Posts",
+          "Post",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the Post",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/PostRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/PostResponse",
@@ -14501,9 +14965,9 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a Post",
+        "summary": "Update a specific Post",
         "tags": [
-          "Posts",
+          "Post",
         ],
       },
     },
@@ -14619,7 +15083,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
         },
         "responses": {
           "201": {
-            "$ref": "#/components/responses/NewUsersResponse",
+            "$ref": "#/components/responses/UsersResponse",
           },
         },
         "security": [
@@ -14635,6 +15099,16 @@ exports[`openapi generators > handles non-default collection 1`] = `
     },
     "/api/users/{id}": {
       "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -14648,12 +15122,43 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Delete a users",
+        "summary": "Delete a specific users",
         "tags": [
           "users",
         ],
       },
       "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "depth",
+            "schema": {
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "fallback-locale",
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -14667,44 +15172,25 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Find a users by ID",
+        "summary": "Retrieve a specific users",
         "tags": [
           "users",
         ],
       },
-      "parameters": [
-        {
-          "in": "query",
-          "name": "depth",
-          "schema": {
-            "type": "number",
-          },
-        },
-        {
-          "in": "query",
-          "name": "locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "in": "query",
-          "name": "fallback-locale",
-          "schema": {
-            "type": "string",
-          },
-        },
-        {
-          "description": "ID of the users",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "string",
-          },
-        },
-      ],
       "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UsersRequestBody",
+        },
         "responses": {
           "200": {
             "$ref": "#/components/responses/UsersResponse",
@@ -14718,7 +15204,7 @@ exports[`openapi generators > handles non-default collection 1`] = `
             "ApiKey": [],
           },
         ],
-        "summary": "Update a users",
+        "summary": "Update a specific users",
         "tags": [
           "users",
         ],

--- a/test/advanced-filtering.test.ts
+++ b/test/advanced-filtering.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest'
+import type { Collection, SanitizedGlobalConfig, Field } from 'payload'
+import { 
+  filterCollections, 
+  filterGlobals, 
+  shouldIncludeOperation, 
+  filterFields
+} from '../src/utils/filtering.js'
+import type { CRUDOperation } from '../src/types.js'
+
+describe('Advanced Filtering utilities', () => {
+  const mockCollections = {
+    posts: {
+      config: { slug: 'posts', auth: false, access: { read: true } }
+    } as unknown as Collection,
+    users: {
+      config: { slug: 'users', auth: true }
+    } as unknown as Collection,
+    'payload-preferences': {
+      config: { slug: 'payload-preferences', auth: false }
+    } as unknown as Collection,
+    'internal-data': {
+      config: { slug: 'internal-data', auth: false, access: { read: false } }
+    } as unknown as Collection,
+  }
+
+  const mockFields: Field[] = [
+    { type: 'text', name: 'title' } as Field,
+    { type: 'password', name: 'password' } as Field,
+    { type: 'text', name: 'email' } as Field,
+    { type: 'text', name: '_internal' } as Field,
+    { type: 'text', name: 'secretKey' } as Field,
+  ]
+
+  describe('filterCollections with hideInternalCollections', () => {
+    it('should hide payload-* collections when hideInternalCollections is true', () => {
+      const result = filterCollections(mockCollections, {
+        hideInternalCollections: true
+      })
+      expect(result).toHaveLength(3)
+      expect(result.map(c => c.config.slug)).not.toContain('payload-preferences')
+    })
+
+    it('should include payload-* collections when hideInternalCollections is false', () => {
+      const result = filterCollections(mockCollections, {
+        hideInternalCollections: false
+      })
+      expect(result).toHaveLength(4)
+      expect(result.map(c => c.config.slug)).toContain('payload-preferences')
+    })
+
+    it('should combine hideInternalCollections with other filters', () => {
+      const result = filterCollections(mockCollections, {
+        hideInternalCollections: true,
+        includeCollections: ['posts', 'users', 'payload-preferences']
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
+    })
+  })
+
+  describe('shouldIncludeOperation', () => {
+    const mockCollection = mockCollections.posts
+
+    it('should include all operations when no filter is provided', () => {
+      const operations: CRUDOperation[] = ['create', 'read', 'update', 'delete', 'list']
+      operations.forEach(op => {
+        expect(shouldIncludeOperation(op, mockCollection, {})).toBe(true)
+      })
+    })
+
+    it('should only include specified operations when includeOperations is set', () => {
+      const options = {
+        operations: {
+          includeOperations: ['read', 'list'] as CRUDOperation[]
+        }
+      }
+      
+      expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
+      expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
+    })
+
+    it('should exclude specified operations when excludeOperations is set', () => {
+      const options = {
+        operations: {
+          excludeOperations: ['delete', 'create'] as CRUDOperation[]
+        }
+      }
+      
+      expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('update', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
+      expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
+    })
+
+    it('should use custom operationFilter when provided', () => {
+      const options = {
+        operations: {
+          operationFilter: (operation: CRUDOperation, collection: any) => {
+            // Only allow read operations for posts
+            if (collection.slug === 'posts') {
+              return operation === 'read'
+            }
+            return true
+          }
+        }
+      }
+      
+      expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
+    })
+  })
+
+  describe('filterFields', () => {
+    const mockCollection = mockCollections.posts
+
+    it('should return all fields when no filter is provided', () => {
+      const result = filterFields(mockFields, mockCollection, {})
+      expect(result).toHaveLength(5)
+    })
+
+    it('should exclude specified fields when excludeFields is an array', () => {
+      const result = filterFields(mockFields, mockCollection, {
+        excludeFields: ['password', 'secretKey']
+      })
+      expect(result.map(f => (f as any).name)).not.toContain('password')
+      expect(result.map(f => (f as any).name)).not.toContain('secretKey')
+      expect(result.map(f => (f as any).name)).toContain('title')
+    })
+
+    it('should use custom field filter function', () => {
+      const result = filterFields(mockFields, mockCollection, {
+        excludeFields: ({ name, type }) => {
+          return type === 'password' || name.startsWith('_')
+        }
+      })
+      expect(result.map(f => (f as any).name)).not.toContain('password')
+      expect(result.map(f => (f as any).name)).not.toContain('_internal')
+      expect(result.map(f => (f as any).name)).toContain('title')
+      expect(result.map(f => (f as any).name)).toContain('secretKey')
+    })
+
+    it('should use custom field filter function with collection information', () => {
+      const result = filterFields(mockFields, mockCollection, {
+        excludeFields: ({ name, type, collection }) => {
+          // Different rules for different collections
+          if (collection.slug === 'posts') {
+            // For posts, exclude password and internal fields
+            return type === 'password' || name.startsWith('_')
+          }
+          // For other collections, only exclude password
+          return type === 'password'
+        }
+      })
+      expect(result.map(f => (f as any).name)).not.toContain('password')
+      expect(result.map(f => (f as any).name)).not.toContain('_internal')
+      expect(result.map(f => (f as any).name)).toContain('title')
+      expect(result.map(f => (f as any).name)).toContain('secretKey')
+    })
+
+    it('should filter differently for different collections', () => {
+      const usersCollection = mockCollections.users
+      
+      // For users collection, exclude different fields
+      const result = filterFields(mockFields, usersCollection, {
+        excludeFields: ({ name, collection }) => {
+          if (collection.slug === 'users') {
+            // For users, exclude secretKey but allow _internal
+            return name === 'secretKey'
+          }
+          return false
+        }
+      })
+      expect(result.map(f => (f as any).name)).toContain('password')
+      expect(result.map(f => (f as any).name)).toContain('_internal')
+      expect(result.map(f => (f as any).name)).not.toContain('secretKey')
+      expect(result.map(f => (f as any).name)).toContain('title')
+    })
+  })
+
+  describe('operation filtering integration', () => {
+    it('should respect excludeOperations configuration', () => {
+      const mockCollection = mockCollections.posts
+      
+      // Test that delete operation is excluded
+      const options = {
+        operations: {
+          excludeOperations: ['delete'] as CRUDOperation[]
+        }
+      }
+      
+      expect(shouldIncludeOperation('create', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('update', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
+    })
+
+    it('should respect includeOperations configuration', () => {
+      const mockCollection = mockCollections.posts
+      
+      // Test that only read and list operations are included
+      const options = {
+        operations: {
+          includeOperations: ['read', 'list'] as CRUDOperation[]
+        }
+      }
+      
+      expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
+      expect(shouldIncludeOperation('update', mockCollection, options)).toBe(false)
+      expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
+    })
+
+    it('should respect custom operationFilter', () => {
+      const mockCollection = mockCollections.posts
+      
+      // Test custom operation filter
+      const options = {
+        operations: {
+          operationFilter: (operation: CRUDOperation, collection: any) => {
+            // Only allow read operations for posts
+            if (collection.slug === 'posts') {
+              return operation === 'read' || operation === 'list'
+            }
+            return true
+          }
+        }
+      }
+      
+      expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
+      expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
+      expect(shouldIncludeOperation('update', mockCollection, options)).toBe(false)
+      expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
+    })
+  })
+}) 

--- a/test/advanced-filtering.test.ts
+++ b/test/advanced-filtering.test.ts
@@ -1,26 +1,26 @@
-import { describe, it, expect } from 'vitest'
-import type { Collection, SanitizedGlobalConfig, Field } from 'payload'
-import { 
-  filterCollections, 
-  filterGlobals, 
-  shouldIncludeOperation, 
-  filterFields
-} from '../src/utils/filtering.js'
+import type { Collection, Field, SanitizedGlobalConfig } from 'payload'
+import { describe, expect, it } from 'vitest'
 import type { CRUDOperation } from '../src/types.js'
+import {
+  filterCollections,
+  filterFields,
+  filterGlobals,
+  shouldIncludeOperation,
+} from '../src/utils/filtering.js'
 
 describe('Advanced Filtering utilities', () => {
   const mockCollections = {
     posts: {
-      config: { slug: 'posts', auth: false, access: { read: true } }
+      config: { slug: 'posts', auth: false, access: { read: true } },
     } as unknown as Collection,
     users: {
-      config: { slug: 'users', auth: true }
+      config: { slug: 'users', auth: true },
     } as unknown as Collection,
     'payload-preferences': {
-      config: { slug: 'payload-preferences', auth: false }
+      config: { slug: 'payload-preferences', auth: false },
     } as unknown as Collection,
     'internal-data': {
-      config: { slug: 'internal-data', auth: false, access: { read: false } }
+      config: { slug: 'internal-data', auth: false, access: { read: false } },
     } as unknown as Collection,
   }
 
@@ -35,7 +35,7 @@ describe('Advanced Filtering utilities', () => {
   describe('filterCollections with hideInternalCollections', () => {
     it('should hide payload-* collections when hideInternalCollections is true', () => {
       const result = filterCollections(mockCollections, {
-        hideInternalCollections: true
+        hideInternalCollections: true,
       })
       expect(result).toHaveLength(3)
       expect(result.map(c => c.config.slug)).not.toContain('payload-preferences')
@@ -43,7 +43,7 @@ describe('Advanced Filtering utilities', () => {
 
     it('should include payload-* collections when hideInternalCollections is false', () => {
       const result = filterCollections(mockCollections, {
-        hideInternalCollections: false
+        hideInternalCollections: false,
       })
       expect(result).toHaveLength(4)
       expect(result.map(c => c.config.slug)).toContain('payload-preferences')
@@ -52,7 +52,7 @@ describe('Advanced Filtering utilities', () => {
     it('should combine hideInternalCollections with other filters', () => {
       const result = filterCollections(mockCollections, {
         hideInternalCollections: true,
-        includeCollections: ['posts', 'users', 'payload-preferences']
+        includeCollections: ['posts', 'users', 'payload-preferences'],
       })
       expect(result).toHaveLength(2)
       expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
@@ -64,18 +64,18 @@ describe('Advanced Filtering utilities', () => {
 
     it('should include all operations when no filter is provided', () => {
       const operations: CRUDOperation[] = ['create', 'read', 'update', 'delete', 'list']
-      operations.forEach(op => {
+      for (const op of operations) {
         expect(shouldIncludeOperation(op, mockCollection, {})).toBe(true)
-      })
+      }
     })
 
     it('should only include specified operations when includeOperations is set', () => {
       const options = {
         operations: {
-          includeOperations: ['read', 'list'] as CRUDOperation[]
-        }
+          includeOperations: ['read', 'list'] as CRUDOperation[],
+        },
       }
-      
+
       expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
@@ -85,10 +85,10 @@ describe('Advanced Filtering utilities', () => {
     it('should exclude specified operations when excludeOperations is set', () => {
       const options = {
         operations: {
-          excludeOperations: ['delete', 'create'] as CRUDOperation[]
-        }
+          excludeOperations: ['delete', 'create'] as CRUDOperation[],
+        },
       }
-      
+
       expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('update', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
@@ -104,10 +104,10 @@ describe('Advanced Filtering utilities', () => {
               return operation === 'read'
             }
             return true
-          }
-        }
+          },
+        },
       }
-      
+
       expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
     })
@@ -123,7 +123,7 @@ describe('Advanced Filtering utilities', () => {
 
     it('should exclude specified fields when excludeFields is an array', () => {
       const result = filterFields(mockFields, mockCollection, {
-        excludeFields: ['password', 'secretKey']
+        excludeFields: ['password', 'secretKey'],
       })
       expect(result.map(f => (f as any).name)).not.toContain('password')
       expect(result.map(f => (f as any).name)).not.toContain('secretKey')
@@ -134,7 +134,7 @@ describe('Advanced Filtering utilities', () => {
       const result = filterFields(mockFields, mockCollection, {
         excludeFields: ({ name, type }) => {
           return type === 'password' || name.startsWith('_')
-        }
+        },
       })
       expect(result.map(f => (f as any).name)).not.toContain('password')
       expect(result.map(f => (f as any).name)).not.toContain('_internal')
@@ -152,7 +152,7 @@ describe('Advanced Filtering utilities', () => {
           }
           // For other collections, only exclude password
           return type === 'password'
-        }
+        },
       })
       expect(result.map(f => (f as any).name)).not.toContain('password')
       expect(result.map(f => (f as any).name)).not.toContain('_internal')
@@ -162,7 +162,7 @@ describe('Advanced Filtering utilities', () => {
 
     it('should filter differently for different collections', () => {
       const usersCollection = mockCollections.users
-      
+
       // For users collection, exclude different fields
       const result = filterFields(mockFields, usersCollection, {
         excludeFields: ({ name, collection }) => {
@@ -171,7 +171,7 @@ describe('Advanced Filtering utilities', () => {
             return name === 'secretKey'
           }
           return false
-        }
+        },
       })
       expect(result.map(f => (f as any).name)).toContain('password')
       expect(result.map(f => (f as any).name)).toContain('_internal')
@@ -183,14 +183,14 @@ describe('Advanced Filtering utilities', () => {
   describe('operation filtering integration', () => {
     it('should respect excludeOperations configuration', () => {
       const mockCollection = mockCollections.posts
-      
+
       // Test that delete operation is excluded
       const options = {
         operations: {
-          excludeOperations: ['delete'] as CRUDOperation[]
-        }
+          excludeOperations: ['delete'] as CRUDOperation[],
+        },
       }
-      
+
       expect(shouldIncludeOperation('create', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('update', mockCollection, options)).toBe(true)
@@ -200,14 +200,14 @@ describe('Advanced Filtering utilities', () => {
 
     it('should respect includeOperations configuration', () => {
       const mockCollection = mockCollections.posts
-      
+
       // Test that only read and list operations are included
       const options = {
         operations: {
-          includeOperations: ['read', 'list'] as CRUDOperation[]
-        }
+          includeOperations: ['read', 'list'] as CRUDOperation[],
+        },
       }
-      
+
       expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
@@ -217,7 +217,7 @@ describe('Advanced Filtering utilities', () => {
 
     it('should respect custom operationFilter', () => {
       const mockCollection = mockCollections.posts
-      
+
       // Test custom operation filter
       const options = {
         operations: {
@@ -227,10 +227,10 @@ describe('Advanced Filtering utilities', () => {
               return operation === 'read' || operation === 'list'
             }
             return true
-          }
-        }
+          },
+        },
       }
-      
+
       expect(shouldIncludeOperation('read', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('list', mockCollection, options)).toBe(true)
       expect(shouldIncludeOperation('create', mockCollection, options)).toBe(false)
@@ -238,4 +238,4 @@ describe('Advanced Filtering utilities', () => {
       expect(shouldIncludeOperation('delete', mockCollection, options)).toBe(false)
     })
   })
-}) 
+})

--- a/test/filtering.test.ts
+++ b/test/filtering.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect } from 'vitest'
 import type { Collection, SanitizedGlobalConfig } from 'payload'
+import { describe, expect, it } from 'vitest'
 import { filterCollections, filterGlobals } from '../src/utils/filtering.js'
 
 describe('Filtering utilities', () => {
   const mockCollections = {
     posts: {
-      config: { slug: 'posts', auth: false }
+      config: { slug: 'posts', auth: false },
     } as unknown as Collection,
     users: {
-      config: { slug: 'users', auth: true }
+      config: { slug: 'users', auth: true },
     } as unknown as Collection,
     media: {
-      config: { slug: 'media', auth: false }
+      config: { slug: 'media', auth: false },
     } as unknown as Collection,
   }
 
@@ -30,7 +30,7 @@ describe('Filtering utilities', () => {
 
     it('should include only specified collections when includeCollections is an array', () => {
       const result = filterCollections(mockCollections, {
-        includeCollections: ['posts', 'users']
+        includeCollections: ['posts', 'users'],
       })
       expect(result).toHaveLength(2)
       expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
@@ -38,7 +38,7 @@ describe('Filtering utilities', () => {
 
     it('should exclude specified collections when excludeCollections is an array', () => {
       const result = filterCollections(mockCollections, {
-        excludeCollections: ['media']
+        excludeCollections: ['media'],
       })
       expect(result).toHaveLength(2)
       expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
@@ -46,7 +46,7 @@ describe('Filtering utilities', () => {
 
     it('should work with custom filter functions', () => {
       const result = filterCollections(mockCollections, {
-        includeCollections: ({ config }) => config.auth === true
+        includeCollections: ({ config }) => config.auth === true,
       })
       expect(result).toHaveLength(1)
       expect(result[0].config.slug).toBe('users')
@@ -55,7 +55,7 @@ describe('Filtering utilities', () => {
     it('should apply both include and exclude filters', () => {
       const result = filterCollections(mockCollections, {
         includeCollections: ['posts', 'users', 'media'],
-        excludeCollections: ['media']
+        excludeCollections: ['media'],
       })
       expect(result).toHaveLength(2)
       expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
@@ -71,7 +71,7 @@ describe('Filtering utilities', () => {
 
     it('should include only specified globals when includeGlobals is an array', () => {
       const result = filterGlobals(mockGlobals, {
-        includeGlobals: ['settings', 'public-info']
+        includeGlobals: ['settings', 'public-info'],
       })
       expect(result).toHaveLength(2)
       expect(result.map(g => g.slug)).toEqual(['settings', 'public-info'])
@@ -79,7 +79,7 @@ describe('Filtering utilities', () => {
 
     it('should exclude specified globals when excludeGlobals is an array', () => {
       const result = filterGlobals(mockGlobals, {
-        excludeGlobals: ['internal-config']
+        excludeGlobals: ['internal-config'],
       })
       expect(result).toHaveLength(2)
       expect(result.map(g => g.slug)).toEqual(['settings', 'public-info'])
@@ -87,7 +87,7 @@ describe('Filtering utilities', () => {
 
     it('should work with custom filter functions', () => {
       const result = filterGlobals(mockGlobals, {
-        excludeGlobals: ({ slug }) => slug.startsWith('internal-')
+        excludeGlobals: ({ slug }) => slug.startsWith('internal-'),
       })
       expect(result).toHaveLength(2)
       expect(result.map(g => g.slug)).toEqual(['settings', 'public-info'])
@@ -96,10 +96,10 @@ describe('Filtering utilities', () => {
     it('should apply both include and exclude filters', () => {
       const result = filterGlobals(mockGlobals, {
         includeGlobals: ['settings', 'internal-config'],
-        excludeGlobals: ['internal-config']
+        excludeGlobals: ['internal-config'],
       })
       expect(result).toHaveLength(1)
       expect(result[0].slug).toBe('settings')
     })
   })
-}) 
+})

--- a/test/filtering.test.ts
+++ b/test/filtering.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import type { Collection, SanitizedGlobalConfig } from 'payload'
+import { filterCollections, filterGlobals } from '../src/utils/filtering.js'
+
+describe('Filtering utilities', () => {
+  const mockCollections = {
+    posts: {
+      config: { slug: 'posts', auth: false }
+    } as unknown as Collection,
+    users: {
+      config: { slug: 'users', auth: true }
+    } as unknown as Collection,
+    media: {
+      config: { slug: 'media', auth: false }
+    } as unknown as Collection,
+  }
+
+  const mockGlobals = [
+    { slug: 'settings' } as SanitizedGlobalConfig,
+    { slug: 'internal-config' } as SanitizedGlobalConfig,
+    { slug: 'public-info' } as SanitizedGlobalConfig,
+  ]
+
+  describe('filterCollections', () => {
+    it('should return all collections when no filters are provided', () => {
+      const result = filterCollections(mockCollections, {})
+      expect(result).toHaveLength(3)
+      expect(result.map(c => c.config.slug)).toEqual(['posts', 'users', 'media'])
+    })
+
+    it('should include only specified collections when includeCollections is an array', () => {
+      const result = filterCollections(mockCollections, {
+        includeCollections: ['posts', 'users']
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
+    })
+
+    it('should exclude specified collections when excludeCollections is an array', () => {
+      const result = filterCollections(mockCollections, {
+        excludeCollections: ['media']
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
+    })
+
+    it('should work with custom filter functions', () => {
+      const result = filterCollections(mockCollections, {
+        includeCollections: ({ config }) => config.auth === true
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0].config.slug).toBe('users')
+    })
+
+    it('should apply both include and exclude filters', () => {
+      const result = filterCollections(mockCollections, {
+        includeCollections: ['posts', 'users', 'media'],
+        excludeCollections: ['media']
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(c => c.config.slug)).toEqual(['posts', 'users'])
+    })
+  })
+
+  describe('filterGlobals', () => {
+    it('should return all globals when no filters are provided', () => {
+      const result = filterGlobals(mockGlobals, {})
+      expect(result).toHaveLength(3)
+      expect(result.map(g => g.slug)).toEqual(['settings', 'internal-config', 'public-info'])
+    })
+
+    it('should include only specified globals when includeGlobals is an array', () => {
+      const result = filterGlobals(mockGlobals, {
+        includeGlobals: ['settings', 'public-info']
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(g => g.slug)).toEqual(['settings', 'public-info'])
+    })
+
+    it('should exclude specified globals when excludeGlobals is an array', () => {
+      const result = filterGlobals(mockGlobals, {
+        excludeGlobals: ['internal-config']
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(g => g.slug)).toEqual(['settings', 'public-info'])
+    })
+
+    it('should work with custom filter functions', () => {
+      const result = filterGlobals(mockGlobals, {
+        excludeGlobals: ({ slug }) => slug.startsWith('internal-')
+      })
+      expect(result).toHaveLength(2)
+      expect(result.map(g => g.slug)).toEqual(['settings', 'public-info'])
+    })
+
+    it('should apply both include and exclude filters', () => {
+      const result = filterGlobals(mockGlobals, {
+        includeGlobals: ['settings', 'internal-config'],
+        excludeGlobals: ['internal-config']
+      })
+      expect(result).toHaveLength(1)
+      expect(result[0].slug).toBe('settings')
+    })
+  })
+}) 


### PR DESCRIPTION
## Filtering and Control Options

### Collection and Global Filtering

Control which collections and globals are included in the OpenAPI specification:

```typescript
import { openapi } from 'payload-oapi'

// Basic filtering with arrays
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Public API', version: '1.0.0' },
      
      // Include only specific collections
      includeCollections: ['posts', 'categories'],
      
      // Exclude sensitive globals
      excludeGlobals: ['internal-settings'],
      
      // Hide internal Payload collections (payload-preferences, payload-migrations)
      hideInternalCollections: true,
    }),
  ],
})

// Advanced filtering with functions
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Public API', version: '1.0.0' },
      
      // Custom filtering with functions
      includeCollections: ({ slug, config }) => {
        return config.auth || config.access?.read === true
      },
      
      excludeGlobals: ({ slug, config }) => {
        return slug.startsWith('internal-')
      },
    }),
  ],
})
```

### Operation-Level Filtering

Control which CRUD operations are included for collections:

```typescript
import { openapi } from 'payload-oapi'

// Include only specific operations
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Read-Only API', version: '1.0.0' },
      
      operations: {
        includeOperations: ['read', 'list'],
      },
    }),
  ],
})

// Exclude dangerous operations
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Safe API', version: '1.0.0' },
      
      operations: {
        excludeOperations: ['delete'],
      },
    }),
  ],
})

// Custom operation filtering per collection
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Custom API', version: '1.0.0' },
      
      operations: {
        operationFilter: (operation, collection) => {
          // Only allow read operations for sensitive collections
          if (collection.slug === 'users') {
            return ['read', 'list'].includes(operation)
          }
          // Allow all operations for other collections
          return true
        }
      },
    }),
  ],
})
```

### Field-Level Filtering

Control which fields are exposed in the documentation:

```typescript
import { openapi } from 'payload-oapi'

// Exclude specific fields by name
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Clean API', version: '1.0.0' },
      
      excludeFields: ['internalNotes', 'adminComments'],
    }),
  ],
})

// Custom field filtering by type and name
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Secure API', version: '1.0.0' },
      
      excludeFields: ({ name, type }) => {
        // Exclude all password-type fields and internal fields
        return type === 'password' || name.startsWith('_')
      },
    }),
  ],
})

// Advanced field filtering with collection context
buildConfig({
  plugins: [
    openapi({
      openapiVersion: '3.0',
      metadata: { title: 'Context-Aware API', version: '1.0.0' },
      
      excludeFields: ({ name, type, collection }) => {
        // Different filtering rules for different collections
        if (collection.slug === 'users') {
          // For users, exclude sensitive fields
          return ['password', 'salt', 'hash', 'resetPasswordToken'].includes(name)
        }
        
        if (collection.slug === 'posts') {
          // For posts, exclude internal fields and drafts
          return name.startsWith('_') || name === 'draft'
        }
        
        // For other collections, only exclude password fields
        return type === 'password'
      },
    }),
  ],
})
```