### PR TITLE
fix: add missing Scalar plugin import to index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import openapi from './openapiPlugin.js'
 import rapidoc from './rapidocPlugin.js'
 import redoc from './redocPlugin.js'
-import swaggerUI from './swaggerUIPlugin.js'
 import scalar from './scalarPlugin.js'
+import swaggerUI from './swaggerUIPlugin.js'
 
-export { openapi, swaggerUI, rapidoc, redoc, scalar };
+export { openapi, swaggerUI, rapidoc, redoc, scalar }


### PR DESCRIPTION
Thanks to [@fabioquarantini](https://github.com/fabioquarantini) for the Scalar plugin!

The plugin was not being imported to and exported from `src/index.ts`, which made it unavailable for use in the project. This PR adds the missing import and export to ensure the plugin is properly registered and usable